### PR TITLE
Move GH Hook to JS land

### DIFF
--- a/scripts/hubot-pr-status.coffee
+++ b/scripts/hubot-pr-status.coffee
@@ -131,10 +131,19 @@ module.exports = (robot) ->
     # everytime a PR is closed and merged. The `merged` key gives us the second
     # piece of information.
     pr_action    = data.action
-    merge_action = data.pull_request.merged
-    pr_number    = data.pull_request.number
+    closedPr     = data.pull_request
+    merge_action = closedPr.merged
+    pr_number    = closedPr.number
 
     if pr_action == "closed" and merge_action == true
+      msgData = {
+        channel: "general"
+        text: "<#{closedPr.html_url}|##{closedPr.number} _#{closedPr.title}_>
+        got merged; checking to see if it created any conflicts…"
+        mrkdwn_in: ["text"]
+      }
+      robot.adapter.customMessage msgData
+
       postMergeHook = new PostMergeHook(pr_number)
       postMergeHook.generateMessage().then (message) =>
         msgData = {

--- a/scripts/post_merge_hook.coffee
+++ b/scripts/post_merge_hook.coffee
@@ -33,17 +33,15 @@ class PostMergeHook
 
        if @unMergeablePrs(allPrs).length
          text = "
-           <#{closedPr.Links.html.href}|##{closedPr.number} _#{closedPr.title}_>
-           was merged; it might've created some merge conflicts
-         "
-
+           There are merge conflicts. Run `@bot status conflicts` for more info
+           "
          {
            text: text
            attachments: message.attachments
          }
        else
          {
-           text: "A PR was closed; didn't create any conflicts 👍🏽"
+           text: "No conflicts 👍🏽"
          }
 
 module.exports = PostMergeHook

--- a/scripts/status_all.coffee
+++ b/scripts/status_all.coffee
@@ -65,7 +65,7 @@ class StatusAll
         stats += "#{mergeablePrCount} mergeable\n"
         stats += "#{unMergeablePrCount} unmergeable\n"
         stats += "\n"
-        stats += "Run `status conflicts` to know details about unmergeable pulls"
+        stats += "Run `@bot status conflicts` to know details about unmergeable pulls"
         stats += "\n"
       else
         stats = "No open PRs :tada:"


### PR DESCRIPTION
- Remove superflous `if` condition
  
  Slack caters to the case where `attachments` value in the customMessage
  argument is a blank array. We don't have to manually check it.
- Move GH hook to JS land
  
  This is the hook that listens to the GitHub post request when a PR is closed
  or opened etc. We filter out all the actions and only run the bot's message
  sending routine only if the PR is a merge.
